### PR TITLE
deps: upgrade parent POM, junit, qulice, plugins, and GitHub Actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,19 +12,19 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
       - run: mvn install -Pjacoco
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/site/jacoco/jacoco.xml

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: yegor256/copyrights-action@0.0.8
+      - uses: actions/checkout@v6
+      - uses: yegor256/copyrights-action@0.0.12

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v20.0.0
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v23

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-15, windows-2022 ]
-        java: [ 11, 21 ]
+        os: [ubuntu-24.04, macos-15, windows-2022]
+        java: [11, 21]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2022]
-        java: [11, 21]
+        java: [21]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: volodya-lombrozo/pdd-action@master

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: fsfe/reuse-action@v5

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: crate-ci/typos@v1.32.0

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: g4s8/xcop-action@master

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ibiqlik/action-yamllint@v3

--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ the `master` branch, if they look correct.
 
 Please run Maven build before submitting a pull request:
 
-```
-$ mvn clean install -Pqulice
+```bash
+mvn clean install -Pqulice
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.39.0</version>
+    <version>1.44.0</version>
   </parent>
   <groupId>com.yegor256</groupId>
   <artifactId>jping-maven-plugin</artifactId>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -67,53 +67,53 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.9.9</version>
+      <version>3.9.15</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.9.9</version>
+      <version>3.9.15</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>3.3.0</version>
+      <version>3.5.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.15.1</version>
+      <version>3.15.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.10.3</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.10.3</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>jaxec</artifactId>
-      <version>0.3.1</version>
+      <version>0.5.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>farea</artifactId>
-      <version>0.2.0</version>
+      <version>0.15.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>jping</artifactId>
-      <version>0.0.3</version>
+      <version>0.1.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -179,7 +179,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.24.0</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/it.*</exclude>

--- a/src/main/java/com/yegor256/JpingMojo.java
+++ b/src/main/java/com/yegor256/JpingMojo.java
@@ -23,7 +23,6 @@ import org.slf4j.impl.StaticLoggerBinder;
 
 /**
  * Checks whether the host machine is connected to the Internet.
- *
  * @since 0.0.1
  */
 @Mojo(
@@ -162,5 +161,4 @@ public final class JpingMojo extends AbstractMojo {
         }
         return online;
     }
-
 }

--- a/src/main/java/com/yegor256/package-info.java
+++ b/src/main/java/com/yegor256/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Maven plugin that checks that a connection to the Internet exists.
- *
  * @since 0.0.1
  */
 package com.yegor256;

--- a/src/test/java/com/yegor256/JpingMojoTest.java
+++ b/src/test/java/com/yegor256/JpingMojoTest.java
@@ -14,14 +14,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link com.yegor256.JpingMojo}.
- *
  * @since 0.0.1
  */
 final class JpingMojoTest {
 
     @Test
     @ExtendWith(WeAreOnline.class)
-    void testSimpleScenario(@TempDir final Path temp) throws Exception {
+    void runsSimpleScenario(@TempDir final Path temp) throws Exception {
         new Farea(temp).together(
             f -> {
                 f.build()
@@ -35,7 +34,7 @@ final class JpingMojoTest {
                 f.exec("initialize");
                 MatcherAssert.assertThat(
                     "Sets property correctly",
-                    f.log(),
+                    f.log().content(),
                     Matchers.containsString("${foo} set to \"true\"")
                 );
             }
@@ -43,7 +42,7 @@ final class JpingMojoTest {
     }
 
     @Test
-    void testWhenOffline(@TempDir final Path temp) throws Exception {
+    void worksWhenOffline(@TempDir final Path temp) throws Exception {
         new Farea(temp).together(
             f -> {
                 f.build()
@@ -57,11 +56,10 @@ final class JpingMojoTest {
                 f.exec("initialize");
                 MatcherAssert.assertThat(
                     "Sets property correctly (even when offline)",
-                    f.log(),
+                    f.log().content(),
                     Matchers.containsString("Property ${bar} ")
                 );
             }
         );
     }
-
 }

--- a/src/test/java/com/yegor256/package-info.java
+++ b/src/test/java/com/yegor256/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Maven plugin that checks that a connection to the Internet exists.
- *
  * @since 0.0.1
  */
 package com.yegor256;


### PR DESCRIPTION
@yegor256 — this PR upgrades all stale dependencies, plugins, and GitHub Actions to their latest stable versions, and incidentally fixes the `markdown-lint` and `yamllint` failures that were already red on `master`.

## What's upgraded

### Maven dependencies (in `pom.xml`)
| Artifact | From | To |
|---|---|---|
| `com.jcabi:jcabi` (parent POM) | 1.39.0 | 1.44.0 |
| `org.junit.jupiter:junit-jupiter-api`/`-engine` | 5.10.3 | 6.0.3 |
| `org.apache.maven:maven-core` | 3.9.9 | 3.9.15 |
| `org.apache.maven:maven-plugin-api` | 3.9.9 | 3.9.15 |
| `org.apache.maven.plugin-testing:maven-plugin-testing-harness` | 3.3.0 | 3.5.1 |
| `org.apache.maven.plugin-tools:maven-plugin-annotations` | 3.15.1 | 3.15.2 |
| `org.slf4j:slf4j-reload4j` | 2.0.16 | 2.0.17 |
| `com.yegor256:jaxec` | 0.3.1 | 0.5.1 |
| `com.yegor256:farea` | 0.2.0 | 0.15.4 |
| `com.yegor256:jping` | 0.0.3 | 0.1.0 |
| `com.qulice:qulice-maven-plugin` | 0.24.0 | 0.27.6 |

### GitHub Actions (in `.github/workflows/*.yml`)
- `actions/checkout` v4 → v6
- `actions/setup-java` v4 → v5
- `actions/cache` v4 → v5
- `codecov/codecov-action` v5 → v6
- `yegor256/copyrights-action` 0.0.8 → 0.0.12
- `DavidAnson/markdownlint-cli2-action` v20.0.0 → v23

## Code changes required by the upgrades

- **`farea` 0.15.4** changed `Farea#log()` to return `Requisite` instead of `String`. `JpingMojoTest` now calls `.content()` to obtain the string.
- **`junit-jupiter` 6.x requires Java 17+** and the parent POM 1.44.0 imports `junit-bom:6.0.3` via `<dependencyManagement>`. The CI matrix in `.github/workflows/mvn.yml` previously included Java 11, which is no longer compatible. I dropped Java 11 and kept Java 21 only — this matches the convention used in other yegor256 plugins (`jaxec`, `jhome`, etc.).
- **`qulice` 0.27.6** added stricter Checkstyle rules. Adjustments:
  - Removed empty Javadoc lines before `@since` tags (`JavadocEmptyLineBeforeTagCheck`).
  - Removed empty lines before closing braces (`RegexpMultilineCheck`).
  - Renamed `testSimpleScenario`/`testWhenOffline` to `runsSimpleScenario`/`worksWhenOffline` (`ProhibitTestMethodNameCheck`).

## Pre-existing failures fixed on `master`

These were red on `master` before this PR; both are addressed here so they no longer block the lint matrix:

- `markdown-lint`: `README.md`'s shell snippet now has a `bash` language hint and drops the `$` prompt (`MD040`, `MD014`).
- `yamllint`: removed the inner spaces in the matrix arrays of `mvn.yml` (`brackets`).

## Local verification

On Java 21, with the qulice profile:

```bash
mvn --batch-mode --errors clean install -Pqulice
```

…runs to `BUILD SUCCESS` (compile, surefire test, invoker IT, qulice all pass). `yamllint .` and `markdownlint-cli2 "**/*.md"` are also clean.

## Heads up on CI

GitHub flagged this fork-based PR's workflow runs as `action_required` (the standard "first-time contributor" gate). The actual CI won't execute until you click *Approve and run* on the Actions tab — once approved, all jobs that pass on `master` should pass here, plus `markdown-lint` and `yamllint` should now be green.

There are several open Renovate PRs (#32 jaxec, #34 farea, #38 slf4j-reload4j, #41/#42 maven-core/maven-plugin-api, #45 junit, #47 jcabi parent, #48 qulice). This PR supersedes all of them with a single coherent upgrade — feel free to close them after merging.
